### PR TITLE
商品詳細ページのルーティング設定

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,13 +2,14 @@ import './App.css';
 import React, { useState } from 'react'
 import productList from './model/products';
 import ProductPage from './pages/ProductPage';
+import ProductDetailPage from './pages/ProductDetailPage';
 import Header from './components/Header';
 import FavoritePage from './pages/FavoritePage';
-// import ProductDetailPage from './pages/ProductDetailPage'
 import CartPage from './pages/CartPage';
 import NoMatch from './pages/NoMatch';
 
 import { Routes, Route } from 'react-router-dom'
+
 
 const App = () => {
   const [products, setProducts] = useState(productList);
@@ -20,6 +21,15 @@ const App = () => {
       <Routes>
         <Route path="/" element={
           <ProductPage
+            products={products}
+            setProducts={setProducts}
+            cart={cart}
+            setCart={setCart}
+          />}
+        >
+        </Route>
+        <Route path=":productName" element={
+          <ProductDetailPage
             products={products}
             setProducts={setProducts}
             cart={cart}
@@ -42,9 +52,9 @@ const App = () => {
           setCart={setCart}
           />}
         />
+
         <Route path="*" element={<NoMatch/>} />
       </Routes>
-      {/* <ProductDetailPage/> */}
     </div>
   );
 }

--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import styled from '@emotion/styled';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -39,7 +40,7 @@ const Item = ({item, products, setProducts, cart, setCart}) => {
 
     setCart(prevState => [...prevState, {
       ...item,
-      amount: 1
+      quantity: 1
     }]);
 
   }
@@ -73,7 +74,9 @@ const Item = ({item, products, setProducts, cart, setCart}) => {
     <Box m={2}>
       <Card sx={{ minWidth: 275}} className="rem20">
         <ProductCardContent>
-          <Image image={item.image} />
+          <Link to={`/${item.productName}`}>
+            <Image image={item.image} />
+          </Link>
           <Title title={item.productName} />
           <Price price={item.price} />
           <Stack direction={"row"} justifyContent={"end"} alignItems={"center"}>

--- a/src/pages/CartPage.jsx
+++ b/src/pages/CartPage.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { Box, Typography, Grid, FormControl, OutlinedInput, InputAdornment, Button, Divider } from "@mui/material"
 
 const CartPage = ({products, setProducts, cart, setCart}) => {
@@ -23,7 +24,6 @@ const CartPage = ({products, setProducts, cart, setCart}) => {
       <Typography sx={{mt: 1}} variant="h3" component="h1">Shopping Cart</Typography>
 
       <Grid container>
-
         <Grid item xs={12} md={8} >
           <Box sx={{p: 1, mr: {xs: 0, md: 1}, mb: 1}}>
             <Divider/>
@@ -76,14 +76,16 @@ const CartItem = ({item, products, setProducts, cart, setCart}) => {
     <>
       <Grid container sx={{my: 1}}>
         <Grid item xs={3} >
-          <Image image={item.image} />
+          <Link to={`/${item.productName}`}>
+            <Image image={item.image} />
+          </Link>
         </Grid>
         <Grid item xs={5} sx={{display: "flex", justifyContent: "center", alignItems: "center"}}>
           <Title title={item.productName} />
         </Grid>
         <Grid item xs={4} sx={{display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "end"}}>
           <Price price={item.price} />
-          <Amount amount={item.amount} />
+          <Quantity quantity={item.quantity} />
           <DeleteCartButton onClick={() => removeShoppingCart()} />
         </Grid>
       </Grid>
@@ -112,7 +114,7 @@ const Price = (props) => {
   )
 }
 
-const Amount = (props) => {
+const Quantity = (props) => {
 
   return (
     <Box sx={{display: "flex", justifyContent: "space-between", alignItems: "center"}}>
@@ -123,7 +125,7 @@ const Amount = (props) => {
           id="delete-from-cart"
           type='number'
           name="delete-from-cart"
-          value={props.amount}
+          value={props.quantity}
           // onChange={handleChange}
           endAdornment={<InputAdornment position="end">個</InputAdornment>}
           size="small"
@@ -136,7 +138,7 @@ const Amount = (props) => {
 const DeleteCartButton = (props) => {
   return (
     <Box sx={{display: "flex", justifyContent: "end", my: 1}}>
-      <Button sx={{minWidth: 135}} color="primary" variant="contained" disableElevation onClick={props.onClick}>
+      <Button sx={{minWidth: 135}} color="secondary" variant="contained" disableElevation onClick={props.onClick}>
         カートから削除
       </Button>
     </Box>

--- a/src/pages/FavoritePage.jsx
+++ b/src/pages/FavoritePage.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { Box, Divider, Typography, Button, Grid } from "@mui/material"
 
 const FavoritePage = ({products, setProducts, cart, setCart}) => {
@@ -61,7 +62,7 @@ const FavoriteItem = ({item, products, setProducts, cart, setCart}) => {
 
     setCart(prevState => [...prevState, {
       ...item,
-      amount: 1
+      quantity: 1
     }]);
 
   }
@@ -87,7 +88,9 @@ const FavoriteItem = ({item, products, setProducts, cart, setCart}) => {
     <>
       <Grid container alignItems="center" sx={{my: 1}}>
         <Grid item xs={5} sm={3} sx={{display: "flex", justifyContent: "center"}}>
-          <Image image={item.image}/>
+          <Link to={`/${item.productName}`}>
+            <Image image={item.image}/>
+          </Link>
         </Grid>
         <Box sx={{flexGrow: 1}}></Box>
         <Grid container item xs={7} sm={9} justifyContent="end">

--- a/src/pages/ProductDetailPage.jsx
+++ b/src/pages/ProductDetailPage.jsx
@@ -1,11 +1,72 @@
-import { Typography, Box, Button, Grid } from "@mui/material";
+import React, { useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { Typography, Box, Button, Grid, InputLabel, MenuItem, FormControl, Select } from "@mui/material";
 
-import InputLabel from '@mui/material/InputLabel';
-import MenuItem from '@mui/material/MenuItem';
-import FormControl from '@mui/material/FormControl';
-import Select from '@mui/material/Select';
+const ProductDetailPage = ({products, setProducts, cart, setCart}) => {
+  const [ quantity, setQuantity ] = useState(1);
+  const navigate = useNavigate();
 
-const ProductDetailPage = (props) => {
+  const handleChange = (event) => {
+    setQuantity(event.target.value);
+  };
+
+  const params = useParams();
+  const product = products.find((product) => {
+    return product.productName === params.productName;
+  });
+
+  // お気に入りの切替
+  const handleToggleFavorite = (item) => {
+    const newProductList = products.map((product) => {
+      if (product.productName === item.productName) {
+        product.isFavorite = !product.isFavorite;
+      }
+      return product;
+    });
+    setProducts(newProductList);
+  }
+
+  // 買い物かご切替
+  const handeleToggleShoppingCart = (item) => {
+    if (!item.isInCart) addShoppingCart(item);
+    else removeShoppingCart(item);
+  }
+
+  // 買い物かごへの追加
+  const addShoppingCart = (item) => {
+
+    const newProductList = products.map((product) => {
+      if (product.productName === item.productName) {
+        product.isInCart = !product.isInCart;
+      }
+      return product;
+    });
+    setProducts(newProductList);
+
+    setCart(prevState => [...prevState, {
+      ...item,
+      quantity: quantity
+    }]);
+
+  }
+
+  // 買い物かごからの削除
+  const removeShoppingCart = (item) => {
+    
+    const newCartList = [...cart].filter((product) => {
+      return product.productName !== item.productName;
+    });
+    setCart(newCartList);
+
+    const newProductList = products.map((product) => {
+      if (product.productName === item.productName) {
+        product.isInCart = !product.isInCart;
+      }
+      return product;
+    });
+    setProducts(newProductList);
+  }
+
   return (
     <div className="container">
       <Typography sx={{mt: 1}} variant="h3" component="h1">Product Datail</Typography>
@@ -13,60 +74,60 @@ const ProductDetailPage = (props) => {
         <Grid item xs={12} md={8}>
           <Box sx={{border: "solid 2px grey", p: 1, mr: {xs: 0, md: 1}, mb: 1}}>
             <Box sx={{width: "100%", height: 300}} >
-              <Box sx={{objectFit: "contain", width: "100%", height: "100%"}} component="img" src="images/ipad-air.jpeg" alt="" />
+              <Box sx={{objectFit: "contain", width: "100%", height: "100%"}} component="img" src={product.image} alt="" />
             </Box>
             <Box sx={{display: "flex", justifyContent: "space-between"}}>
-              <Title/>
-              <Price/>
+              <Title title={product.productName} />
+              <Price price={product.price} />
             </Box>
             <Box>
-              <Description/>
+              <Description description={product.description} />
             </Box>
           </Box>
         </Grid>
         <Grid item xs={12} md={4}>
           <Box sx={{width: "100%", border: "solid 2px grey", p: 1}}>
-            <Box sx={{display: "flex", justifyContent: "space-between"}}>
-              <p>単価</p>
-              <Price/>
+            <Box sx={{display: "flex", justifyContent: "space-between", alignItems: "center"}}>
+            <Typography sx={{m: 0}} paragraph={true}>単価</Typography>
+              <Price price={product.price}/>
             </Box>
-            <Box sx={{display: "flex", justifyContent: "space-between"}}>
-              <p>数量</p>
-              <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
-                <InputLabel id="demo-select-small">amount</InputLabel>
+            <Box sx={{display: "flex", justifyContent: "space-between", alignItems: "center"}}>
+            <Typography sx={{m: 0}} paragraph={true}>数量</Typography>
+              <FormControl sx={{ m: 1, minWidth: 100 }} size="small">
+                <InputLabel id="demo-select-small">quantity</InputLabel>
                 <Select
                   labelId="demo-select-small"
                   id="demo-select-small"
-                  value=""
-                  label="amount"
-                  // onChange={handleChange}
+                  defaultValue={quantity}
+                  value={quantity}
+                  label="quantity"
+                  onChange={(event) => handleChange(event)}
                 >
-                  <MenuItem value="">
-                    <em>None</em>
-                  </MenuItem>
                   <MenuItem value={1}>1</MenuItem>
                   <MenuItem value={2}>2</MenuItem>
                   <MenuItem value={3}>3</MenuItem>
+                  <MenuItem value={4}>4</MenuItem>
+                  <MenuItem value={5}>5</MenuItem>
                 </Select>
               </FormControl>
             </Box>
             <Box sx={{display: "flex", justifyContent: "space-between", alignItems: "center"}}>
-              <p>合計</p>
-              <p>148,280円</p>
+              <Typography sx={{m: 0}} paragraph={true}>合計</Typography>
+              <Price price={product.price * quantity} />
             </Box>
             <Box>
               <Box sx={{display: "flex", justifyContent: "end", my:1}}>
-                <Button sx={{minWidth: 170}} color="warning" variant="contained" disableElevation>
-                  お気に入りに追加
+                <Button onClick={() => handleToggleFavorite(product)} sx={{minWidth: 170}} color="warning" variant="contained" disableElevation>
+                  {product.isFavorite ? "お気に入りから削除" : "お気に入りに追加"}
                 </Button>
               </Box>
               <Box sx={{display: "flex", justifyContent: "end", my: 1}}>
-                <Button sx={{minWidth: 170}} color="secondary" variant="contained" disableElevation>
-                  カートに追加する
+                <Button onClick={() => handeleToggleShoppingCart(product)} sx={{minWidth: 170}} color="secondary" variant="contained" disableElevation>
+                  {product.isInCart ? "カートから削除" : "カートに追加する"}
                 </Button>
               </Box>
               <Box sx={{display: "flex", justifyContent: "end", my: 1}}>
-                <Button sx={{minWidth: 170}} color="primary" variant="contained" disableElevation>
+                <Button onClick={() => navigate('/cart')} sx={{minWidth: 170}} color="primary" variant="contained" disableElevation>
                   カートに移動する
                 </Button>
               </Box>
@@ -80,22 +141,20 @@ const ProductDetailPage = (props) => {
 
 const Title = (props) => {
   return (
-    <Typography variant="h4" component="h2">Mac Book Air</Typography>
+    <Typography variant="h4" component="h2">{props.title}</Typography>
   )
 }
 
 const Price = (props) => {
   return (
-    <Typography sx={{m: 0}} variant="h6" paragraph={true}>148,280円</Typography>
+    <Typography sx={{m: 0}} variant="h6" paragraph={true}>{props.price.toLocaleString()}円</Typography>
   )
 }
 
 const Description = (props) => {
   return (
     <Box sx={{width: "100%", border: "solid 2px grey", p: 1}}>
-      <Typography paragraph={true}>
-        M1チップを内蔵したMacBook Airは、驚くほどポータブルなノートブックです。軽快かつスピーディーな使い心地。静かなファンレス設計。美しいRetinaディスプレイ。飛ぶように軽々と持ち運べるのは、スリムなボディと一日中使えるバッテリーのおかげです。
-      </Typography>
+      <Typography paragraph={true}>{props.description}</Typography>
     </Box>
   )
 }

--- a/src/pages/ProductPage.jsx
+++ b/src/pages/ProductPage.jsx
@@ -1,11 +1,11 @@
-import React, {useState} from 'react';
-import InputLabel from '@mui/material/InputLabel';
+import React, {useState} from 'react';import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import Select from '@mui/material/Select';
 
 import Category from "../components/Category";
 import { Box } from '@mui/material';
+
 
 const ProductPage = ({products, setProducts, cart, setCart}) => {
 


### PR DESCRIPTION
1. 商品詳細ページのルーティング設定
　・各ページの商品の画像をクリックすると商品詳細ページに移動する
2. 詳細ページのお気に入り登録・削除
3. 買い物かご登録・削除
4. 購入ページへの移動設定